### PR TITLE
DEFRA-FFC-147251: Setting CPH as n/a in session event

### DIFF
--- a/app/event/send-session-event.js
+++ b/app/event/send-session-event.js
@@ -5,7 +5,7 @@ const sendSessionEvent = async (organisation, sessionId, entryKey, key, value, i
     const event = {
       id: sessionId,
       sbi: organisation.sbi,
-      cph: organisation.cph,
+      cph: 'n/a',
       email: organisation.email,
       name: 'send-session-event',
       type: `${entryKey}-${key}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-farmer-apply",
-      "version": "0.24.9",
+      "version": "0.24.10",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.24.10",
+  "version": "0.24.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-farmer-apply",
-      "version": "0.24.10",
+      "version": "0.24.11",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "description": "Web frontend for the farmer apply journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-apply",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.24.10",
+  "version": "0.24.11",
   "description": "Web frontend for the farmer apply journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-apply",
   "main": "app/index.js",

--- a/test/unit/app/event/send-session-event.test.js
+++ b/test/unit/app/event/send-session-event.test.js
@@ -40,7 +40,7 @@ describe('Send event on session set', () => {
       ...event,
       sbi: organisation.sbi,
       email: organisation.email,
-      cph: organisation.cph,
+      cph: 'n/a',
       id: sessionId,
       data: { [key]: value },
       ip


### PR DESCRIPTION
Setting CPH as n/a as this identifier is not available from the new auto eligibility API and ultimately the data warehouse extract. The session event is currently being rejected by the Joi validation.