### PR TITLE
chore(AHWR-20): export config object directly

### DIFF
--- a/app/config/auth.js
+++ b/app/config/auth.js
@@ -1,6 +1,6 @@
 const Joi = require('joi')
 
-const authSchema = Joi.object({
+const schema = Joi.object({
   defraId: {
     hostname: Joi.string().uri(),
     oAuthAuthorisePath: Joi.string(),
@@ -31,7 +31,7 @@ const authSchema = Joi.object({
   }
 })
 
-const authConfig = {
+const config = {
   defraId: {
     hostname: `https://${process.env.DEFRA_ID_TENANT}.b2clogin.com/${process.env.DEFRA_ID_TENANT}.onmicrosoft.com`,
     oAuthAuthorisePath: '/oauth2/v2.0/authorize',
@@ -62,12 +62,13 @@ const authConfig = {
   }
 }
 
-const authResult = authSchema.validate(authConfig, {
-  abortEarly: false
+const { error } = schema.validate(config, {
+  abortEarly: false,
+  convert: false
 })
 
-if (authResult.error) {
-  throw new Error(`The auth config is invalid. ${authResult.error.message}`)
+if (error) {
+  throw new Error(`The auth config is invalid. ${error.message}`)
 }
 
-module.exports = authResult.value
+module.exports = config

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -3,65 +3,68 @@ const mqConfig = require('./messaging')
 const authConfig = require('./auth')
 const urlPrefix = '/apply'
 
+const tenSecondsInMilliseconds = 10000
+const oneDayInMilliseconds = 1000 * 60 * 60 * 24
+const threeDaysInMilliseconds = oneDayInMilliseconds * 3
+const oneYearInMilliseconds = oneDayInMilliseconds * 365
+
 const schema = Joi.object({
   appInsights: Joi.object(),
   namespace: Joi.string().optional(),
   cache: {
-    expiresIn: Joi.number().default(1000 * 3600 * 24 * 3), // 3 days
+    expiresIn: Joi.number(),
     options: {
-      host: Joi.string().default('redis-hostname.default'),
-      partition: Joi.string().default('ffc-ahwr-frontend'),
+      host: Joi.string(),
+      partition: Joi.string(),
       password: Joi.string().allow(''),
-      port: Joi.number().default(6379),
+      port: Joi.number(),
       tls: Joi.object()
     }
   },
   cookie: {
-    cookieNameCookiePolicy: Joi.string().default('ffc_ahwr_cookie_policy'),
-    cookieNameAuth: Joi.string().default('ffc_ahwr_auth'),
-    cookieNameSession: Joi.string().default('ffc_ahwr_session'),
-    isSameSite: Joi.string().default('Lax'),
-    isSecure: Joi.boolean().default(true),
+    cookieNameCookiePolicy: Joi.string(),
+    cookieNameAuth: Joi.string(),
+    cookieNameSession: Joi.string(),
+    isSameSite: Joi.string(),
+    isSecure: Joi.bool(),
     password: Joi.string().min(32).required(),
-    ttl: Joi.number().default(1000 * 3600 * 24 * 3) // 3 days
+    ttl: Joi.number()
   },
   cookiePolicy: {
-    clearInvalid: Joi.bool().default(false),
-    encoding: Joi.string().valid('base64json').default('base64json'),
-    isSameSite: Joi.string().default('Lax'),
-    isSecure: Joi.bool().default(true),
+    clearInvalid: Joi.bool(),
+    encoding: Joi.string().valid('base64json'),
+    isSameSite: Joi.string(),
+    isSecure: Joi.bool(),
     password: Joi.string().min(32).required(),
-    path: Joi.string().default('/'),
-    ttl: Joi.number().default(1000 * 60 * 60 * 24 * 365) // 1 year
+    path: Joi.string(),
+    ttl: Joi.number()
   },
-  env: Joi.string().valid('development', 'test', 'production').default(
-    'development'
-  ),
+  env: Joi.string().valid('development', 'test', 'production'),
   googleTagManagerKey: Joi.string().allow(null, ''),
-  isDev: Joi.boolean().default(false),
-  port: Joi.number().default(3000),
+  isDev: Joi.bool(),
+  port: Joi.number(),
   serviceUri: Joi.string().uri(),
   claimServiceUri: Joi.string().uri(),
   dashboardServiceUri: Joi.string().uri(),
-  serviceName: Joi.string().default('Annual health and welfare review of livestock'),
-  useRedis: Joi.boolean().default(false),
-  urlPrefix: Joi.string().default(urlPrefix),
+  serviceName: Joi.string(),
+  useRedis: Joi.bool(),
+  urlPrefix: Joi.string(),
   ruralPaymentsAgency: {
-    loginUri: Joi.string().uri().default('https://www.ruralpayments.service.gov.uk'),
-    callChargesUri: Joi.string().uri().default('https://www.gov.uk/call-charges'),
-    email: Joi.string().email().default('ruralpayments@defra.gov.uk'),
-    telephone: Joi.string().default('03000 200 301')
+    loginUri: Joi.string().uri(),
+    callChargesUri: Joi.string().uri(),
+    email: Joi.string().email(),
+    telephone: Joi.string()
   },
   customerSurvey: {
     uri: Joi.string().uri().optional()
   },
   applicationApi: require('../api-requests/application-api.config.schema'),
   wreckHttp: {
-    timeoutMilliseconds: Joi.number().default(10000)
+    timeoutMilliseconds: Joi.number()
   },
   latestTermsAndConditionsUri: Joi.string().required(),
   dateOfTesting: {
-    enabled: Joi.bool().default(false)
+    enabled: Joi.bool()
   },
   tenMonthRule: {
     enabled: Joi.bool().default(false)
@@ -76,10 +79,12 @@ const config = {
   appInsights: require('applicationinsights'),
   namespace: process.env.NAMESPACE,
   cache: {
+    expiresIn: threeDaysInMilliseconds,
     options: {
-      host: process.env.REDIS_HOSTNAME,
+      host: process.env.REDIS_HOSTNAME || 'redis-hostname.default',
+      partition: 'ffc-ahwr-frontend',
       password: process.env.REDIS_PASSWORD,
-      port: process.env.REDIS_PORT,
+      port: Number(process.env.REDIS_PORT) || 6379,
       tls: process.env.NODE_ENV === 'production' ? {} : undefined
     }
   },
@@ -89,24 +94,28 @@ const config = {
     cookieNameSession: 'ffc_ahwr_session',
     isSameSite: 'Lax',
     isSecure: process.env.NODE_ENV === 'production',
-    password: process.env.COOKIE_PASSWORD
+    password: process.env.COOKIE_PASSWORD,
+    ttl: threeDaysInMilliseconds
   },
   cookiePolicy: {
     clearInvalid: false,
     encoding: 'base64json',
     isSameSite: 'Lax',
     isSecure: process.env.NODE_ENV === 'production',
-    password: process.env.COOKIE_PASSWORD
+    path: '/',
+    password: process.env.COOKIE_PASSWORD,
+    ttl: oneYearInMilliseconds
   },
-  env: process.env.NODE_ENV,
+  env: process.env.NODE_ENV || 'development',
   googleTagManagerKey: process.env.GOOGLE_TAG_MANAGER_KEY,
   isDev: process.env.NODE_ENV === 'development',
-  port: process.env.PORT,
+  port: Number(process.env.PORT) || 3000,
   serviceUri: process.env.SERVICE_URI,
   claimServiceUri: process.env.CLAIM_SERVICE_URI,
   dashboardServiceUri: process.env.DASHBOARD_SERVICE_URI,
+  serviceName: 'Annual health and welfare review of livestock',
   useRedis: process.env.NODE_ENV !== 'test',
-  urlPrefix: process.env.URL_PREFIX,
+  urlPrefix: process.env.URL_PREFIX || urlPrefix,
   ruralPaymentsAgency: {
     loginUri: 'https://www.ruralpayments.service.gov.uk',
     callChargesUri: 'https://www.gov.uk/call-charges',
@@ -118,31 +127,32 @@ const config = {
   },
   applicationApi: require('../api-requests/application-api.config'),
   wreckHttp: {
-    timeoutMilliseconds: process.env.WRECK_HTTP_TIMEOUT_MILLISECONDS
+    timeoutMilliseconds: Number(process.env.WRECK_HTTP_TIMEOUT_MILLISECONDS) || tenSecondsInMilliseconds
   },
   latestTermsAndConditionsUri: process.env.TERMS_AND_CONDITIONS_URL,
   dateOfTesting: {
-    enabled: process.env.DATE_OF_TESTING_ENABLED
+    enabled: process.env.DATE_OF_TESTING_ENABLED === 'true'
   },
   tenMonthRule: {
-    enabled: process.env.TEN_MONTH_RULE_ENABLED
+    enabled: process.env.TEN_MONTH_RULE_ENABLED === 'true'
   },
   reapplyTimeLimitMonths: 10,
   endemics: {
-    enabled: process.env.ENDEMICS_ENABLED
+    enabled: process.env.ENDEMICS_ENABLED === 'true'
   }
 }
 
-const result = schema.validate(config, {
-  abortEarly: false
+const { error } = schema.validate(config, {
+  abortEarly: false,
+  convert: false
 })
 
-if (result.error) {
-  throw new Error(`The server config is invalid. ${result.error.message}`)
+if (error) {
+  throw new Error(`The server config is invalid. ${error.message}`)
 }
 
-const value = result.value
-value.mqConfig = mqConfig
-value.authConfig = authConfig
-
-module.exports = value
+module.exports = {
+  ...config,
+  mqConfig,
+  authConfig
+}

--- a/app/messaging/application/index.js
+++ b/app/messaging/application/index.js
@@ -1,11 +1,6 @@
 const { sendMessage, receiveMessage } = require('../')
 const states = require('../../constants/states')
-const { applicationRequestQueue, applicationRequestMsgType, fetchApplicationRequestMsgType, applicationResponseQueue } = require('../../config').mqConfig
-
-async function getApplication (applicationReference, sessionId) {
-  await sendMessage({ applicationReference }, fetchApplicationRequestMsgType, applicationRequestQueue, { sessionId })
-  return receiveMessage(sessionId, applicationResponseQueue)
-}
+const { applicationRequestQueue, applicationRequestMsgType, applicationResponseQueue } = require('../../config').mqConfig
 
 async function sendApplication (application, sessionId) {
   await sendMessage(
@@ -28,6 +23,5 @@ async function sendApplication (application, sessionId) {
 }
 
 module.exports = {
-  getApplication,
   sendApplication
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.58.26",
+  "version": "0.58.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-farmer-apply",
-      "version": "0.58.26",
+      "version": "0.58.27",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.2.1",
@@ -29,7 +29,6 @@
         "jsonwebtoken": "^9.0.0",
         "jwk-to-pem": "^2.0.5",
         "mssql": "^10.0.2",
-        "notifications-node-client": "^8.1.0",
         "nunjucks": "^3.2.3",
         "pg-promise": "^11.5.5",
         "uuid": "^8.3.2",
@@ -3415,17 +3414,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/b4a": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
@@ -6137,25 +6125,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -9565,19 +9534,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/notifications-node-client": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.2.0.tgz",
-      "integrity": "sha512-XGmW2f2CroEwIUrPaTyShpF8pLlu79rBnwWns1uPGs27LbZdzNPJF1BzPl3cG3Tsu3nVlaWeXJJYAE+ALryalA==",
-      "dependencies": {
-        "axios": "^1.6.1",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14.17.3",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/npm-run-all": {
@@ -16365,16 +16321,6 @@
         "possible-typed-array-names": "^1.0.0"
       }
     },
-    "axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "b4a": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
@@ -18330,11 +18276,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -20855,15 +20796,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
       "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w=="
-    },
-    "notifications-node-client": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.2.0.tgz",
-      "integrity": "sha512-XGmW2f2CroEwIUrPaTyShpF8pLlu79rBnwWns1uPGs27LbZdzNPJF1BzPl3cG3Tsu3nVlaWeXJJYAE+ALryalA==",
-      "requires": {
-        "axios": "^1.6.1",
-        "jsonwebtoken": "^9.0.0"
-      }
     },
     "npm-run-all": {
       "version": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,10 +2233,11 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -2836,9 +2837,10 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2850,15 +2852,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -3701,9 +3694,9 @@
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browserslist": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -3719,11 +3712,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001640",
-        "electron-to-chromium": "^1.4.820",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3855,9 +3849,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001641",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
-      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "dev": true,
       "funding": [
         {
@@ -3872,7 +3866,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4256,9 +4251,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4845,15 +4841,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.827",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
-      "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
-      "dev": true
+      "version": "1.5.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -4908,10 +4905,11 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -5121,9 +5119,10 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -9144,10 +9143,11 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -9472,10 +9472,11 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "2.0.22",
@@ -9646,10 +9647,11 @@
       "dev": true
     },
     "node_modules/npm-run-all/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -10342,10 +10344,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -12988,9 +12991,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "funding": [
         {
@@ -13006,9 +13009,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -13255,21 +13259,21 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -15390,9 +15394,9 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "@types/glob": {
@@ -15937,21 +15941,14 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
     },
     "acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "requires": {}
-    },
-    "acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
       "requires": {}
     },
     "acorn-jsx": {
@@ -16595,15 +16592,15 @@
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "browserslist": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001640",
-        "electron-to-chromium": "^1.4.820",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       }
     },
     "bser": {
@@ -16694,9 +16691,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001641",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
-      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "dev": true
     },
     "chalk": {
@@ -16976,9 +16973,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -17377,15 +17374,15 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.827",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
-      "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
+      "version": "1.5.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -17430,9 +17427,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -17595,9 +17592,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-string-regexp": {
       "version": "2.0.0",
@@ -20557,9 +20554,9 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
         "braces": "^3.0.3",
@@ -20788,9 +20785,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
     },
     "nodemon": {
@@ -20921,9 +20918,9 @@
           "dev": true
         },
         "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "version": "6.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+          "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -21427,9 +21424,9 @@
       }
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
@@ -23365,13 +23362,13 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "requires": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       }
     },
     "uri-js": {
@@ -23574,21 +23571,20 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "0.58.26",
+  "version": "0.58.27",
   "description": "Web frontend for the farmer apply journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-apply",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "jsonwebtoken": "^9.0.0",
     "jwk-to-pem": "^2.0.5",
     "mssql": "^10.0.2",
-    "notifications-node-client": "^8.1.0",
     "nunjucks": "^3.2.3",
     "pg-promise": "^11.5.5",
     "uuid": "^8.3.2",

--- a/test/unit/app/config/config.test.js
+++ b/test/unit/app/config/config.test.js
@@ -1,0 +1,7 @@
+test('throws an error for invalid config', () => {
+  jest.resetModules()
+  delete process.env.COOKIE_PASSWORD
+
+  expect(() => require('../../../../app/config'))
+    .toThrow('The server config is invalid. "cookie.password" is required. "cookiePolicy.password" is required')
+})

--- a/test/unit/app/config/config.test.js
+++ b/test/unit/app/config/config.test.js
@@ -1,3 +1,22 @@
+test('uses defaults', () => {
+  jest.resetModules()
+  delete process.env.REDIS_HOSTNAME
+  delete process.env.REDIS_PORT
+  delete process.env.PORT
+  delete process.env.URL_PREFIX
+
+  const config = require('../../../../app/config')
+
+  expect(config.cache.options.host)
+    .toBe('redis-hostname.default')
+  expect(config.cache.options.port)
+    .toBe(6379)
+  expect(config.port)
+    .toBe(3000)
+  expect(config.urlPrefix)
+    .toBe('/apply')
+})
+
 test('throws an error for invalid config', () => {
   jest.resetModules()
   delete process.env.COOKIE_PASSWORD

--- a/test/unit/app/config/config.test.js
+++ b/test/unit/app/config/config.test.js
@@ -13,8 +13,7 @@ test('uses defaults', () => {
     .toBe(6379)
   expect(config.port)
     .toBe(3000)
-  expect(config.urlPrefix)
-    .toBe('/apply')
+  expect(config.urlPrefix).toBe('/apply')
 })
 
 test('throws an error for invalid config', () => {

--- a/test/unit/app/config/config.test.js
+++ b/test/unit/app/config/config.test.js
@@ -13,7 +13,8 @@ test('uses defaults', () => {
     .toBe(6379)
   expect(config.port)
     .toBe(3000)
-  expect(config.urlPrefix).toBe('/apply')
+  expect(config.urlPrefix)
+    .toBe('/apply')
 })
 
 test('throws an error for invalid config', () => {

--- a/test/unit/app/config/messaging.config.test.js
+++ b/test/unit/app/config/messaging.config.test.js
@@ -1,0 +1,7 @@
+test('messaging throws an error for invalid config', () => {
+  jest.resetModules()
+  delete process.env.MESSAGE_QUEUE_HOST
+
+  expect(() => require('../../../../app/config/messaging'))
+    .toThrow('The message queue config is invalid. "messageQueue.host" is required')
+})

--- a/test/unit/app/messaging/application/index.test.js
+++ b/test/unit/app/messaging/application/index.test.js
@@ -1,5 +1,5 @@
-const { getApplication, sendApplication } = require('../../../../../app/messaging/application')
-const { applicationRequestQueue, applicationResponseQueue, fetchApplicationRequestMsgType } = require('../../../../../app/config').mqConfig
+const { sendApplication } = require('../../../../../app/messaging/application')
+const { applicationResponseQueue } = require('../../../../../app/config').mqConfig
 
 jest.mock('../../../../../app/messaging')
 const { receiveMessage, sendMessage } = require('../../../../../app/messaging')
@@ -9,20 +9,6 @@ describe('application messaging tests', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-  })
-
-  test('getApplication sends and receives message', async () => {
-    const reference = 'VV-1234-5678'
-    const receiveMessageRes = { id: 1 }
-    receiveMessage.mockResolvedValue(receiveMessageRes)
-
-    const message = await getApplication(reference, sessionId)
-
-    expect(message).toEqual(receiveMessageRes)
-    expect(receiveMessage).toHaveBeenCalledTimes(1)
-    expect(receiveMessage).toHaveBeenCalledWith(sessionId, applicationResponseQueue)
-    expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationReference: reference }, fetchApplicationRequestMsgType, applicationRequestQueue, { sessionId })
   })
 
   test('sendApplication returns undefined on non submitted state', async () => {


### PR DESCRIPTION
## Description of changes

Export the config object directly rather than coercing it with Joi and then exporting the validation value.

* allows type checking to work
* all properties defined in one place

**Before:**
<img width="325" alt="Screenshot 2024-11-26 at 4 08 39 pm" src="https://github.com/user-attachments/assets/e4c09e08-63b6-4e40-8a03-6f9555742385">

**After:**
<img width="883" alt="Screenshot 2024-11-26 at 4 07 49 pm" src="https://github.com/user-attachments/assets/5d160eb8-abad-464f-afa2-367b0bebc10b">

