### PR TITLE
fix(AHWR-928): Clear reference from session on entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PARENT_VERSION=2.7.2-node22.15.0
+ARG PARENT_VERSION=2.8.4-node22.16.0
 ARG PORT=3000
 ARG PORT_DEBUG=9229
 
@@ -29,5 +29,5 @@ EXPOSE ${PORT}
 
 COPY --from=development /home/node/app/ ./app/
 COPY --from=development /home/node/package*.json ./
-RUN npm ci --ignore-scripts --omit-dev
+RUN npm ci --ignore-scripts --omit=dev
 CMD [ "node", "app" ]

--- a/app/routes/endemics/check-details.js
+++ b/app/routes/endemics/check-details.js
@@ -27,6 +27,8 @@ export const checkDetailsRouteHandlers = [
     path: pageUrl,
     options: {
       handler: async (request, h) => {
+        // on way in we must scrub any lingering reference
+        setFarmerApplyData(request, referenceKey, null);
         const organisation = getFarmerApplyData(request, organisationKey);
 
         if (!organisation) {

--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ffc-ahwr-farmer-apply:
     command: npm run start:debug

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # This override file should be used when running this service in isolation
 # to provide dependencies and expose ports for local testing
 

--- a/docker-compose.test.debug.yaml
+++ b/docker-compose.test.debug.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ffc-ahwr-farmer-apply:
     command: npm run test:debug

--- a/docker-compose.test.watch.yaml
+++ b/docker-compose.test.watch.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ffc-ahwr-farmer-apply:
     command: >

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # This override file should be used when running automated tests so
 # that test output is saved to the host
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ffc-ahwr-farmer-apply:
     build:

--- a/docker-compose.zap.yaml
+++ b/docker-compose.zap.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ffc-ahwr-farmer-apply:
     command: npm run start:watch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "2.4.3",
+  "version": "2.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-farmer-apply",
-      "version": "2.4.3",
+      "version": "2.4.5",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@2toad/profanity": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Web frontend for the farmer apply journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-apply",
   "main": "app/index.js",


### PR DESCRIPTION
Clear reference from session on entry point, to prevent polluting events with reference that may not belong to current sbi in context.

Also upgrade to newer node22 image and fix omitting dev dependencies.