### PR TITLE
fix(AHWR-1356): Correct route offered from error pages

### DIFF
--- a/app/lib/pre-apply-handler.js
+++ b/app/lib/pre-apply-handler.js
@@ -4,6 +4,8 @@ import { applicationType } from "../constants/constants.js";
 import { getApplication, getFarmerApplyData, setApplication } from "../session/index.js";
 import { keys } from "../session/keys.js";
 import { getLatestApplication } from "./utils.js";
+import appInsights from 'applicationinsights'
+import { config } from '../config/index.js'
 
 const { farmerApplyData: { organisation: organisationKey }, application: applicationKey } = keys;
 
@@ -21,8 +23,9 @@ export const preApplyHandler = async (request, h) => {
 
     request.logger.setBindings({ sbi: organisation.sbi });
 
-    if (application?.statusId === CLAIM_STATUS.AGREED && !application.applicationRedacts.length) {
-      throw new Error("User attempted to use apply journey despite already having an agreed agreement.");
+    if (application?.statusId === CLAIM_STATUS.AGREED && !application.applicationRedacts?.length) {
+      appInsights.defaultClient.trackException({ exception: new Error("User attempted to use apply journey despite already having an agreed agreement.") });
+      return h.redirect(`${config.dashboardServiceUri}/vet-visits`).takeover();
     }
   }
 

--- a/app/plugins/error-pages.js
+++ b/app/plugins/error-pages.js
@@ -1,5 +1,4 @@
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../config/index.js';
 
 export const errorPagesPlugin = {
   plugin: {
@@ -33,7 +32,7 @@ export const errorPagesPlugin = {
             "pre response error",
           );
 
-          return h.view("error-pages/500", { applyStartLink: `${config.serviceUri}/you-can-claim-multiple` }).code(statusCode);
+          return h.view("error-pages/500").code(statusCode);
         }
 
         return h.continue;

--- a/app/plugins/view-context.js
+++ b/app/plugins/view-context.js
@@ -28,6 +28,7 @@ export const viewContextPlugin = {
           ctx.dashboardServiceUri = dashboardServiceUri;
           ctx.ruralPaymentsAgency = RPA_CONTACT_DETAILS;
           ctx.userIsSignedIn = request.auth.isAuthenticated
+          ctx.applyStartLink = `${serviceUri}/endemics/you-can-claim-multiple`;
 
           response.source.context = ctx;
         }

--- a/app/routes/missing-routes.js
+++ b/app/routes/missing-routes.js
@@ -16,8 +16,7 @@ export const missingPagesRoutes = [{
       return h
         .view('error-pages/404',
           {
-            signInLink: !userIsSignedIn ? `${config.dashboardServiceUri}/sign-in` : undefined,
-            applyStartLink: `${config.serviceUri}/endemics/you-can-claim-multiple`
+            signInLink: !userIsSignedIn ? `${config.dashboardServiceUri}/sign-in` : undefined
           })
         .code(StatusCodes.NOT_FOUND)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-farmer-apply",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@2toad/profanity": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-farmer-apply",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Web frontend for the farmer apply journey",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-farmer-apply",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/missing-routes.test.js
+++ b/test/integration/narrow/routes/missing-routes.test.js
@@ -31,6 +31,7 @@ describe('Missing routes', () => {
 
     expect($('h1').text()).toMatch('404 - Page not found')
     expect($('p:nth-child(2) > a').text().trim()).toContain('Sign in')
+    expect($('p > a').get(2).attribs.href).toMatch('/endemics/you-can-claim-multiple')
   })
 
   test('GET an unregistered route when user is signed in', async () => {
@@ -49,5 +50,6 @@ describe('Missing routes', () => {
 
     expect($('h1').text()).toMatch('404 - Page not found')
     expect($('p:nth-child(2) > a').text().trim()).not.toContain('Sign in')
+    expect($('p > a').get(2).attribs.href).toMatch('/endemics/you-can-claim-multiple')
   })
 })


### PR DESCRIPTION
Also, if already have an agreement, track exception and send them to dashboard, instead of sending them to an unescapable error page